### PR TITLE
Increase limits

### DIFF
--- a/lua/lib/tags.lua
+++ b/lua/lib/tags.lua
@@ -1,7 +1,7 @@
 tags = tags or {}
 
 tags.MAX_NAME_LIMIT = 20
-tags.MAX_VALUE_LIMIT = 2000
+tags.MAX_VALUE_LIMIT = 4096
 tags.MAX_USER_TAGS = 200
 
 tags.VARS = {

--- a/src/modules/lua/state.rs
+++ b/src/modules/lua/state.rs
@@ -278,7 +278,7 @@ impl LuaState {
                 message_deletions_left: AtomicU64::new(2),
                 images_left: AtomicU64::new(4),
                 image_operations_left: AtomicU64::new(16),
-                instructions: 8388608,
+                instructions: 12_582_912,
             },
             http_rate_limiter: self.http_rate_limiter.clone(),
         }));


### PR DESCRIPTION
Increases some rather arbitrary limits. Tags can now be 4kb in length, and increased instruction limit for math-heavy payloads.

I still consider the instruction limit rather unnecessary as some instructions are more expensive than others, and Kaito's builtins contribute to some of the limit.

Neural network go brrr.