### PR TITLE
Run debug.sethook's hook in a separate coroutine

### DIFF
--- a/lua/sandbox.lua
+++ b/lua/sandbox.lua
@@ -24,19 +24,22 @@ function sandbox.exec(state, fenv, fn)
 
     debug.sethook(
         thread,
-        function()
-            instructions_run = instructions_run + HOOK_EVERY_INSTRUCTION
-            state:set_instructions_run(instructions_run)
-            if instructions_run >= max_instructions then
-                state:terminate("exec")
-                error("Execution quota exceeded")
-            end
+        coroutine.wrap(function()
+            while true do
+                instructions_run = instructions_run + HOOK_EVERY_INSTRUCTION
+                state:set_instructions_run(instructions_run)
+                if instructions_run >= max_instructions then
+                    state:terminate("exec")
+                    error("Execution quota exceeded")
+                end
 
-            if os.clock() > timeout then
-                state:terminate("time")
-                error("Execution time limit reached")
+                if os.clock() > timeout then
+                    state:terminate("time")
+                    error("Execution time limit reached")
+                end
+                coroutine.yield()
             end
-        end,
+        end),
         "",
         HOOK_EVERY_INSTRUCTION
     )


### PR DESCRIPTION
Otherwise, each instruction (up to `HOOK_EVERY_INSTRUCTION`) counts towards the hook counter, making the hook execute a lot more frequently. Uses coroutine.wrap to move the hook to a separate coroutine without incurring any instruction costs for resuming the coroutine, since the resumption happens in C.

Can confirm this works in a stock Lua 5.4 VM, as well as 5.3. Probably also works in 5.1.

![cool](https://c.tenor.com/ceXJoo401McAAAAd/cool-aneurysm.gif)